### PR TITLE
fix(daemon): dialog-agent displays "null" in pop-up content

### DIFF
--- a/src/daemon/DialogAdaptor.cpp
+++ b/src/daemon/DialogAdaptor.cpp
@@ -56,12 +56,16 @@ struct convert<Data> {
             }
         }
 
+        auto getString = [](const Node &n) -> std::string {
+            return (n && !n.IsNull()) ? n.as<std::string>() : std::string();
+        };
+
         rhs.schemas.push_back({
-            QString::fromStdString((*it)["id"].as<std::string>()),
-            QString::fromStdString((*it)["type"].as<std::string>()),
-            (*it)["gettext-domain"] ? QString::fromStdString((*it)["gettext-domain"].as<std::string>()) : "",
-            QString::fromStdString((*it)["description"].as<std::string>()),
-            QString::fromStdString((*it)["message"].as<std::string>()),
+            QString::fromStdString(getString((*it)["id"])),
+            QString::fromStdString(getString((*it)["type"])),
+            QString::fromStdString(getString((*it)["gettext-domain"])),
+            QString::fromStdString(getString((*it)["description"])),
+            QString::fromStdString(getString((*it)["message"])),
             actions,
         });
     }


### PR DESCRIPTION
- Optimized string extraction logic in DialogAdaptor
- Added lambda function `getString` to simplify string retrieval
- Added null node and null value checks to prevent potential
exceptions

---

fix(daemon): dialog-agent 弹窗内容展示为"null"

- 优化DialogAdaptor中字符串提取逻辑
- 添加lambda函数getString简化字符串获取过程
- 添加空节点和空值判断避免潜在异常

Log: 修复Open方法弹窗内容展示为null
PMS: BUG-306705
Influence: 对话框文字显示
